### PR TITLE
chore: add CODEOWNERS file for required reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owner for all files
+* @danjdewhurst


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` setting `@danjdewhurst` as default code owner for all files
- Works with the new branch ruleset to enforce code owner approval on PRs to `main`