### PR TITLE
fix: add release environment to publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
- Adds `environment: release` to the publish job in the release workflow
- Required for npm Trusted Publisher OIDC authentication to match the configured environment

## Test plan
- [ ] Merge and verify next release-please release publishes successfully to npm