### PR TITLE
fix: remove registry-url to allow npm OIDC auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,5 +32,4 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org
       - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- Removes `registry-url` from `actions/setup-node` in the publish job
- `registry-url` creates an `.npmrc` with token-based auth (`NODE_AUTH_TOKEN`), which overrides the OIDC flow needed for Trusted Publishers
- Without it, npm falls through to OIDC authentication automatically

## Test plan
- [ ] Merge and verify next release publishes to npm successfully