### PR TITLE
fix: upgrade npm for trusted publisher OIDC support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,4 +32,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+      - run: npm install -g npm@latest
       - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- Adds `npm install -g npm@latest` before publish step
- Trusted publishing requires npm CLI 11.5.1+, but Node 22 ships with npm 10.x which doesn't support OIDC authentication

## Test plan
- [ ] Merge and verify next release publishes to npm successfully