### PR TITLE
chore: change licence to MIT for Forjd

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Forjd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Transformers.js](https://img.shields.io/badge/embeddings-Transformers.js-FFD21E?logo=huggingface&logoColor=000)](https://huggingface.co/docs/transformers.js)
 [![Biome](https://img.shields.io/badge/linter-Biome-60a5fa?logo=biome&logoColor=fff)](https://biomejs.dev)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178C6?logo=typescript&logoColor=fff)](https://www.typescriptlang.org)
-[![License](https://img.shields.io/badge/licence-private-red)]()
+[![License: MIT](https://img.shields.io/badge/licence-MIT-green.svg)](LICENSE)
 
 Semantic search over your git commit history, right in the terminal.
 
@@ -110,4 +110,4 @@ src/
 
 ## Licence
 
-Private — internal use only.
+[MIT](LICENSE) — Copyright (c) 2025 Forjd

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "type": "git",
     "url": "https://github.com/forjd/git-search.git"
   },
+  "license": "MIT",
   "keywords": [
     "git",
     "search",


### PR DESCRIPTION
## Summary
- Add MIT licence file with Forjd as copyright holder
- Update README badge and footer from "private" to MIT
- Add `license` field to package.json

## Test plan
- [ ] Verify licence badge renders correctly on GitHub
- [ ] Confirm `npm pack` includes the LICENSE file